### PR TITLE
Backport of wrk 4.0.0 changes to wrk2

### DIFF
--- a/src/http_parser.c
+++ b/src/http_parser.c
@@ -56,19 +56,41 @@ do {                                                                 \
   parser->http_errno = (e);                                          \
 } while(0)
 
+#define CURRENT_STATE() p_state
+#define UPDATE_STATE(V) p_state = (enum state) (V);
+#define RETURN(V)                                                    \
+do {                                                                 \
+  parser->state = CURRENT_STATE();                                   \
+  return (V);                                                        \
+} while (0);
+#define REEXECUTE()                                                  \
+  --p;                                                               \
+  break;
+
+
+#ifdef __GNUC__
+# define LIKELY(X) __builtin_expect(!!(X), 1)
+# define UNLIKELY(X) __builtin_expect(!!(X), 0)
+#else
+# define LIKELY(X) (X)
+# define UNLIKELY(X) (X)
+#endif
+
 
 /* Run the notify callback FOR, returning ER if it fails */
 #define CALLBACK_NOTIFY_(FOR, ER)                                    \
 do {                                                                 \
   assert(HTTP_PARSER_ERRNO(parser) == HPE_OK);                       \
                                                                      \
-  if (settings->on_##FOR) {                                          \
-    if (0 != settings->on_##FOR(parser)) {                           \
+  if (LIKELY(settings->on_##FOR)) {                                  \
+    parser->state = CURRENT_STATE();                                 \
+    if (UNLIKELY(0 != settings->on_##FOR(parser))) {                 \
       SET_ERRNO(HPE_CB_##FOR);                                       \
     }                                                                \
+    UPDATE_STATE(parser->state);                                     \
                                                                      \
     /* We either errored above or got paused; get out */             \
-    if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {                       \
+    if (UNLIKELY(HTTP_PARSER_ERRNO(parser) != HPE_OK)) {             \
       return (ER);                                                   \
     }                                                                \
   }                                                                  \
@@ -86,13 +108,16 @@ do {                                                                 \
   assert(HTTP_PARSER_ERRNO(parser) == HPE_OK);                       \
                                                                      \
   if (FOR##_mark) {                                                  \
-    if (settings->on_##FOR) {                                        \
-      if (0 != settings->on_##FOR(parser, FOR##_mark, (LEN))) {      \
+    if (LIKELY(settings->on_##FOR)) {                                \
+      parser->state = CURRENT_STATE();                               \
+      if (UNLIKELY(0 !=                                              \
+                   settings->on_##FOR(parser, FOR##_mark, (LEN)))) { \
         SET_ERRNO(HPE_CB_##FOR);                                     \
       }                                                              \
+      UPDATE_STATE(parser->state);                                   \
                                                                      \
       /* We either errored above or got paused; get out */           \
-      if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {                     \
+      if (UNLIKELY(HTTP_PARSER_ERRNO(parser) != HPE_OK)) {           \
         return (ER);                                                 \
       }                                                              \
     }                                                                \
@@ -113,6 +138,26 @@ do {                                                                 \
 do {                                                                 \
   if (!FOR##_mark) {                                                 \
     FOR##_mark = p;                                                  \
+  }                                                                  \
+} while (0)
+
+/* Don't allow the total size of the HTTP headers (including the status
+ * line) to exceed HTTP_MAX_HEADER_SIZE.  This check is here to protect
+ * embedders against denial-of-service attacks where the attacker feeds
+ * us a never-ending header that the embedder keeps buffering.
+ *
+ * This check is arguably the responsibility of embedders but we're doing
+ * it on the embedder's behalf because most won't bother and this way we
+ * make the web a little safer.  HTTP_MAX_HEADER_SIZE is still far bigger
+ * than any reasonable request or response so this should never affect
+ * day-to-day operation.
+ */
+#define COUNT_HEADER_SIZE(V)                                         \
+do {                                                                 \
+  parser->nread += (V);                                              \
+  if (UNLIKELY(parser->nread > (HTTP_MAX_HEADER_SIZE))) {            \
+    SET_ERRNO(HPE_HEADER_OVERFLOW);                                  \
+    goto error;                                                      \
   }                                                                  \
 } while (0)
 
@@ -248,6 +293,7 @@ enum state
   , s_res_http_minor
   , s_res_first_status_code
   , s_res_status_code
+  , s_res_status_start
   , s_res_status
   , s_res_line_almost_done
 
@@ -279,6 +325,9 @@ enum state
 
   , s_header_field_start
   , s_header_field
+  , s_header_value_discard_ws
+  , s_header_value_discard_ws_almost_done
+  , s_header_value_discard_lws
   , s_header_value_start
   , s_header_value
   , s_header_value_lws
@@ -330,12 +379,16 @@ enum header_states
   , h_upgrade
 
   , h_matching_transfer_encoding_chunked
+  , h_matching_connection_token_start
   , h_matching_connection_keep_alive
   , h_matching_connection_close
+  , h_matching_connection_upgrade
+  , h_matching_connection_token
 
   , h_transfer_encoding_chunked
   , h_connection_keep_alive
   , h_connection_close
+  , h_connection_upgrade
   };
 
 enum http_host_state
@@ -366,6 +419,8 @@ enum http_host_state
 #define IS_USERINFO_CHAR(c) (IS_ALPHANUM(c) || IS_MARK(c) || (c) == '%' || \
   (c) == ';' || (c) == ':' || (c) == '&' || (c) == '=' || (c) == '+' || \
   (c) == '$' || (c) == ',')
+
+#define STRICT_TOKEN(c)     (tokens[(unsigned char)c])
 
 #if HTTP_PARSER_STRICT
 #define TOKEN(c)            (tokens[(unsigned char)c])
@@ -581,6 +636,8 @@ size_t http_parser_execute (http_parser *parser,
   const char *header_value_mark = 0;
   const char *url_mark = 0;
   const char *body_mark = 0;
+  const char *status_mark = 0;
+  enum state p_state = (enum state) parser->state;
 
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
@@ -588,7 +645,7 @@ size_t http_parser_execute (http_parser *parser,
   }
 
   if (len == 0) {
-    switch (parser->state) {
+    switch (CURRENT_STATE()) {
       case s_body_identity_eof:
         /* Use of CALLBACK_NOTIFY() here would erroneously return 1 byte read if
          * we got paused.
@@ -609,11 +666,11 @@ size_t http_parser_execute (http_parser *parser,
   }
 
 
-  if (parser->state == s_header_field)
+  if (CURRENT_STATE() == s_header_field)
     header_field_mark = data;
-  if (parser->state == s_header_value)
+  if (CURRENT_STATE() == s_header_value)
     header_value_mark = data;
-  switch (parser->state) {
+  switch (CURRENT_STATE()) {
   case s_req_path:
   case s_req_schema:
   case s_req_schema_slash:
@@ -627,28 +684,26 @@ size_t http_parser_execute (http_parser *parser,
   case s_req_fragment:
     url_mark = data;
     break;
+  case s_res_status:
+    status_mark = data;
+    break;
+  default:
+    break;
   }
 
   for (p=data; p != data + len; p++) {
     ch = *p;
 
-    if (PARSING_HEADER(parser->state)) {
-      ++parser->nread;
-      /* Buffer overflow attack */
-      if (parser->nread > HTTP_MAX_HEADER_SIZE) {
-        SET_ERRNO(HPE_HEADER_OVERFLOW);
-        goto error;
-      }
-    }
+    if (PARSING_HEADER(CURRENT_STATE()))
+      COUNT_HEADER_SIZE(1);
 
-    reexecute_byte:
-    switch (parser->state) {
+    switch (CURRENT_STATE()) {
 
       case s_dead:
         /* this state is used after a 'Connection: close' message
          * the parser will error out if it reads another message
          */
-        if (ch == CR || ch == LF)
+        if (LIKELY(ch == CR || ch == LF))
           break;
 
         SET_ERRNO(HPE_CLOSED_CONNECTION);
@@ -662,13 +717,13 @@ size_t http_parser_execute (http_parser *parser,
         parser->content_length = ULLONG_MAX;
 
         if (ch == 'H') {
-          parser->state = s_res_or_resp_H;
+          UPDATE_STATE(s_res_or_resp_H);
 
           CALLBACK_NOTIFY(message_begin);
         } else {
           parser->type = HTTP_REQUEST;
-          parser->state = s_start_req;
-          goto reexecute_byte;
+          UPDATE_STATE(s_start_req);
+          REEXECUTE();
         }
 
         break;
@@ -677,9 +732,9 @@ size_t http_parser_execute (http_parser *parser,
       case s_res_or_resp_H:
         if (ch == 'T') {
           parser->type = HTTP_RESPONSE;
-          parser->state = s_res_HT;
+          UPDATE_STATE(s_res_HT);
         } else {
-          if (ch != 'E') {
+          if (UNLIKELY(ch != 'E')) {
             SET_ERRNO(HPE_INVALID_CONSTANT);
             goto error;
           }
@@ -687,7 +742,7 @@ size_t http_parser_execute (http_parser *parser,
           parser->type = HTTP_REQUEST;
           parser->method = HTTP_HEAD;
           parser->index = 2;
-          parser->state = s_req_method;
+          UPDATE_STATE(s_req_method);
         }
         break;
 
@@ -698,7 +753,7 @@ size_t http_parser_execute (http_parser *parser,
 
         switch (ch) {
           case 'H':
-            parser->state = s_res_H;
+            UPDATE_STATE(s_res_H);
             break;
 
           case CR:
@@ -716,39 +771,39 @@ size_t http_parser_execute (http_parser *parser,
 
       case s_res_H:
         STRICT_CHECK(ch != 'T');
-        parser->state = s_res_HT;
+        UPDATE_STATE(s_res_HT);
         break;
 
       case s_res_HT:
         STRICT_CHECK(ch != 'T');
-        parser->state = s_res_HTT;
+        UPDATE_STATE(s_res_HTT);
         break;
 
       case s_res_HTT:
         STRICT_CHECK(ch != 'P');
-        parser->state = s_res_HTTP;
+        UPDATE_STATE(s_res_HTTP);
         break;
 
       case s_res_HTTP:
         STRICT_CHECK(ch != '/');
-        parser->state = s_res_first_http_major;
+        UPDATE_STATE(s_res_first_http_major);
         break;
 
       case s_res_first_http_major:
-        if (ch < '0' || ch > '9') {
+        if (UNLIKELY(ch < '0' || ch > '9')) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
 
         parser->http_major = ch - '0';
-        parser->state = s_res_http_major;
+        UPDATE_STATE(s_res_http_major);
         break;
 
       /* major HTTP version or dot */
       case s_res_http_major:
       {
         if (ch == '.') {
-          parser->state = s_res_first_http_minor;
+          UPDATE_STATE(s_res_first_http_minor);
           break;
         }
 
@@ -760,7 +815,7 @@ size_t http_parser_execute (http_parser *parser,
         parser->http_major *= 10;
         parser->http_major += ch - '0';
 
-        if (parser->http_major > 999) {
+        if (UNLIKELY(parser->http_major > 999)) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
@@ -770,24 +825,24 @@ size_t http_parser_execute (http_parser *parser,
 
       /* first digit of minor HTTP version */
       case s_res_first_http_minor:
-        if (!IS_NUM(ch)) {
+        if (UNLIKELY(!IS_NUM(ch))) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
 
         parser->http_minor = ch - '0';
-        parser->state = s_res_http_minor;
+        UPDATE_STATE(s_res_http_minor);
         break;
 
       /* minor HTTP version or end of request line */
       case s_res_http_minor:
       {
         if (ch == ' ') {
-          parser->state = s_res_first_status_code;
+          UPDATE_STATE(s_res_first_status_code);
           break;
         }
 
-        if (!IS_NUM(ch)) {
+        if (UNLIKELY(!IS_NUM(ch))) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
@@ -795,7 +850,7 @@ size_t http_parser_execute (http_parser *parser,
         parser->http_minor *= 10;
         parser->http_minor += ch - '0';
 
-        if (parser->http_minor > 999) {
+        if (UNLIKELY(parser->http_minor > 999)) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
@@ -814,7 +869,7 @@ size_t http_parser_execute (http_parser *parser,
           goto error;
         }
         parser->status_code = ch - '0';
-        parser->state = s_res_status_code;
+        UPDATE_STATE(s_res_status_code);
         break;
       }
 
@@ -823,13 +878,13 @@ size_t http_parser_execute (http_parser *parser,
         if (!IS_NUM(ch)) {
           switch (ch) {
             case ' ':
-              parser->state = s_res_status;
+              UPDATE_STATE(s_res_status_start);
               break;
             case CR:
-              parser->state = s_res_line_almost_done;
+              UPDATE_STATE(s_res_line_almost_done);
               break;
             case LF:
-              parser->state = s_header_field_start;
+              UPDATE_STATE(s_header_field_start);
               break;
             default:
               SET_ERRNO(HPE_INVALID_STATUS);
@@ -841,7 +896,7 @@ size_t http_parser_execute (http_parser *parser,
         parser->status_code *= 10;
         parser->status_code += ch - '0';
 
-        if (parser->status_code > 999) {
+        if (UNLIKELY(parser->status_code > 999)) {
           SET_ERRNO(HPE_INVALID_STATUS);
           goto error;
         }
@@ -849,24 +904,42 @@ size_t http_parser_execute (http_parser *parser,
         break;
       }
 
-      case s_res_status:
-        /* the human readable status. e.g. "NOT FOUND"
-         * we are not humans so just ignore this */
+      case s_res_status_start:
+      {
         if (ch == CR) {
-          parser->state = s_res_line_almost_done;
+          UPDATE_STATE(s_res_line_almost_done);
           break;
         }
 
         if (ch == LF) {
-          parser->state = s_header_field_start;
+          UPDATE_STATE(s_header_field_start);
           break;
         }
+
+        MARK(status);
+        UPDATE_STATE(s_res_status);
+        parser->index = 0;
+        break;
+      }
+
+      case s_res_status:
+        if (ch == CR) {
+          UPDATE_STATE(s_res_line_almost_done);
+          CALLBACK_DATA(status);
+          break;
+        }
+
+        if (ch == LF) {
+          UPDATE_STATE(s_header_field_start);
+          CALLBACK_DATA(status);
+          break;
+        }
+
         break;
 
       case s_res_line_almost_done:
         STRICT_CHECK(ch != LF);
-        parser->state = s_header_field_start;
-        CALLBACK_NOTIFY(status_complete);
+        UPDATE_STATE(s_header_field_start);
         break;
 
       case s_start_req:
@@ -876,7 +949,7 @@ size_t http_parser_execute (http_parser *parser,
         parser->flags = 0;
         parser->content_length = ULLONG_MAX;
 
-        if (!IS_ALPHA(ch)) {
+        if (UNLIKELY(!IS_ALPHA(ch))) {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;
         }
@@ -889,7 +962,7 @@ size_t http_parser_execute (http_parser *parser,
           case 'G': parser->method = HTTP_GET; break;
           case 'H': parser->method = HTTP_HEAD; break;
           case 'L': parser->method = HTTP_LOCK; break;
-          case 'M': parser->method = HTTP_MKCOL; /* or MOVE, MKACTIVITY, MERGE, M-SEARCH */ break;
+          case 'M': parser->method = HTTP_MKCOL; /* or MOVE, MKACTIVITY, MERGE, M-SEARCH, MKCALENDAR */ break;
           case 'N': parser->method = HTTP_NOTIFY; break;
           case 'O': parser->method = HTTP_OPTIONS; break;
           case 'P': parser->method = HTTP_POST;
@@ -903,7 +976,7 @@ size_t http_parser_execute (http_parser *parser,
             SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
         }
-        parser->state = s_req_method;
+        UPDATE_STATE(s_req_method);
 
         CALLBACK_NOTIFY(message_begin);
 
@@ -913,14 +986,14 @@ size_t http_parser_execute (http_parser *parser,
       case s_req_method:
       {
         const char *matcher;
-        if (ch == '\0') {
+        if (UNLIKELY(ch == '\0')) {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;
         }
 
         matcher = method_strings[parser->method];
         if (ch == ' ' && matcher[parser->index] == '\0') {
-          parser->state = s_req_spaces_before_url;
+          UPDATE_STATE(s_req_spaces_before_url);
         } else if (ch == matcher[parser->index]) {
           ; /* nada */
         } else if (parser->method == HTTP_CONNECT) {
@@ -929,6 +1002,7 @@ size_t http_parser_execute (http_parser *parser,
           } else if (parser->index == 2  && ch == 'P') {
             parser->method = HTTP_COPY;
           } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
           }
         } else if (parser->method == HTTP_MKCOL) {
@@ -940,13 +1014,17 @@ size_t http_parser_execute (http_parser *parser,
             parser->method = HTTP_MSEARCH;
           } else if (parser->index == 2 && ch == 'A') {
             parser->method = HTTP_MKACTIVITY;
+          } else if (parser->index == 3 && ch == 'A') {
+            parser->method = HTTP_MKCALENDAR;
           } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
           }
         } else if (parser->method == HTTP_SUBSCRIBE) {
           if (parser->index == 1 && ch == 'E') {
             parser->method = HTTP_SEARCH;
           } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
           }
         } else if (parser->index == 1 && parser->method == HTTP_POST) {
@@ -957,13 +1035,27 @@ size_t http_parser_execute (http_parser *parser,
           } else if (ch == 'A') {
             parser->method = HTTP_PATCH;
           } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
           }
         } else if (parser->index == 2) {
           if (parser->method == HTTP_PUT) {
-            if (ch == 'R') parser->method = HTTP_PURGE;
+            if (ch == 'R') {
+              parser->method = HTTP_PURGE;
+            } else {
+              SET_ERRNO(HPE_INVALID_METHOD);
+              goto error;
+            }
           } else if (parser->method == HTTP_UNLOCK) {
-            if (ch == 'S') parser->method = HTTP_UNSUBSCRIBE;
+            if (ch == 'S') {
+              parser->method = HTTP_UNSUBSCRIBE;
+            } else {
+              SET_ERRNO(HPE_INVALID_METHOD);
+              goto error;
+            }
+          } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
           }
         } else if (parser->index == 4 && parser->method == HTTP_PROPFIND && ch == 'P') {
           parser->method = HTTP_PROPPATCH;
@@ -982,11 +1074,11 @@ size_t http_parser_execute (http_parser *parser,
 
         MARK(url);
         if (parser->method == HTTP_CONNECT) {
-          parser->state = s_req_server_start;
+          UPDATE_STATE(s_req_server_start);
         }
 
-        parser->state = parse_url_char((enum state)parser->state, ch);
-        if (parser->state == s_dead) {
+        UPDATE_STATE(parse_url_char(CURRENT_STATE(), ch));
+        if (UNLIKELY(CURRENT_STATE() == s_dead)) {
           SET_ERRNO(HPE_INVALID_URL);
           goto error;
         }
@@ -1007,8 +1099,8 @@ size_t http_parser_execute (http_parser *parser,
             SET_ERRNO(HPE_INVALID_URL);
             goto error;
           default:
-            parser->state = parse_url_char((enum state)parser->state, ch);
-            if (parser->state == s_dead) {
+            UPDATE_STATE(parse_url_char(CURRENT_STATE(), ch));
+            if (UNLIKELY(CURRENT_STATE() == s_dead)) {
               SET_ERRNO(HPE_INVALID_URL);
               goto error;
             }
@@ -1027,21 +1119,21 @@ size_t http_parser_execute (http_parser *parser,
       {
         switch (ch) {
           case ' ':
-            parser->state = s_req_http_start;
+            UPDATE_STATE(s_req_http_start);
             CALLBACK_DATA(url);
             break;
           case CR:
           case LF:
             parser->http_major = 0;
             parser->http_minor = 9;
-            parser->state = (ch == CR) ?
+            UPDATE_STATE((ch == CR) ?
               s_req_line_almost_done :
-              s_header_field_start;
+              s_header_field_start);
             CALLBACK_DATA(url);
             break;
           default:
-            parser->state = parse_url_char((enum state)parser->state, ch);
-            if (parser->state == s_dead) {
+            UPDATE_STATE(parse_url_char(CURRENT_STATE(), ch));
+            if (UNLIKELY(CURRENT_STATE() == s_dead)) {
               SET_ERRNO(HPE_INVALID_URL);
               goto error;
             }
@@ -1052,7 +1144,7 @@ size_t http_parser_execute (http_parser *parser,
       case s_req_http_start:
         switch (ch) {
           case 'H':
-            parser->state = s_req_http_H;
+            UPDATE_STATE(s_req_http_H);
             break;
           case ' ':
             break;
@@ -1064,44 +1156,44 @@ size_t http_parser_execute (http_parser *parser,
 
       case s_req_http_H:
         STRICT_CHECK(ch != 'T');
-        parser->state = s_req_http_HT;
+        UPDATE_STATE(s_req_http_HT);
         break;
 
       case s_req_http_HT:
         STRICT_CHECK(ch != 'T');
-        parser->state = s_req_http_HTT;
+        UPDATE_STATE(s_req_http_HTT);
         break;
 
       case s_req_http_HTT:
         STRICT_CHECK(ch != 'P');
-        parser->state = s_req_http_HTTP;
+        UPDATE_STATE(s_req_http_HTTP);
         break;
 
       case s_req_http_HTTP:
         STRICT_CHECK(ch != '/');
-        parser->state = s_req_first_http_major;
+        UPDATE_STATE(s_req_first_http_major);
         break;
 
       /* first digit of major HTTP version */
       case s_req_first_http_major:
-        if (ch < '1' || ch > '9') {
+        if (UNLIKELY(ch < '1' || ch > '9')) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
 
         parser->http_major = ch - '0';
-        parser->state = s_req_http_major;
+        UPDATE_STATE(s_req_http_major);
         break;
 
       /* major HTTP version or dot */
       case s_req_http_major:
       {
         if (ch == '.') {
-          parser->state = s_req_first_http_minor;
+          UPDATE_STATE(s_req_first_http_minor);
           break;
         }
 
-        if (!IS_NUM(ch)) {
+        if (UNLIKELY(!IS_NUM(ch))) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
@@ -1109,7 +1201,7 @@ size_t http_parser_execute (http_parser *parser,
         parser->http_major *= 10;
         parser->http_major += ch - '0';
 
-        if (parser->http_major > 999) {
+        if (UNLIKELY(parser->http_major > 999)) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
@@ -1119,31 +1211,31 @@ size_t http_parser_execute (http_parser *parser,
 
       /* first digit of minor HTTP version */
       case s_req_first_http_minor:
-        if (!IS_NUM(ch)) {
+        if (UNLIKELY(!IS_NUM(ch))) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
 
         parser->http_minor = ch - '0';
-        parser->state = s_req_http_minor;
+        UPDATE_STATE(s_req_http_minor);
         break;
 
       /* minor HTTP version or end of request line */
       case s_req_http_minor:
       {
         if (ch == CR) {
-          parser->state = s_req_line_almost_done;
+          UPDATE_STATE(s_req_line_almost_done);
           break;
         }
 
         if (ch == LF) {
-          parser->state = s_header_field_start;
+          UPDATE_STATE(s_header_field_start);
           break;
         }
 
         /* XXX allow spaces after digit? */
 
-        if (!IS_NUM(ch)) {
+        if (UNLIKELY(!IS_NUM(ch))) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
@@ -1151,7 +1243,7 @@ size_t http_parser_execute (http_parser *parser,
         parser->http_minor *= 10;
         parser->http_minor += ch - '0';
 
-        if (parser->http_minor > 999) {
+        if (UNLIKELY(parser->http_minor > 999)) {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
@@ -1162,32 +1254,32 @@ size_t http_parser_execute (http_parser *parser,
       /* end of request line */
       case s_req_line_almost_done:
       {
-        if (ch != LF) {
+        if (UNLIKELY(ch != LF)) {
           SET_ERRNO(HPE_LF_EXPECTED);
           goto error;
         }
 
-        parser->state = s_header_field_start;
+        UPDATE_STATE(s_header_field_start);
         break;
       }
 
       case s_header_field_start:
       {
         if (ch == CR) {
-          parser->state = s_headers_almost_done;
+          UPDATE_STATE(s_headers_almost_done);
           break;
         }
 
         if (ch == LF) {
           /* they might be just sending \n instead of \r\n so this would be
            * the second \n to denote the end of headers*/
-          parser->state = s_headers_almost_done;
-          goto reexecute_byte;
+          UPDATE_STATE(s_headers_almost_done);
+          REEXECUTE();
         }
 
         c = TOKEN(ch);
 
-        if (!c) {
+        if (UNLIKELY(!c)) {
           SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
           goto error;
         }
@@ -1195,7 +1287,7 @@ size_t http_parser_execute (http_parser *parser,
         MARK(header_field);
 
         parser->index = 0;
-        parser->state = s_header_field;
+        UPDATE_STATE(s_header_field);
 
         switch (c) {
           case 'c':
@@ -1223,9 +1315,14 @@ size_t http_parser_execute (http_parser *parser,
 
       case s_header_field:
       {
-        c = TOKEN(ch);
+        const char* start = p;
+        for (; p != data + len; p++) {
+          ch = *p;
+          c = TOKEN(ch);
 
-        if (c) {
+          if (!c)
+            break;
+
           switch (parser->header_state) {
             case h_general:
               break;
@@ -1326,23 +1423,17 @@ size_t http_parser_execute (http_parser *parser,
               assert(0 && "Unknown header_state");
               break;
           }
+        }
+
+        COUNT_HEADER_SIZE(p - start);
+
+        if (p == data + len) {
+          --p;
           break;
         }
 
         if (ch == ':') {
-          parser->state = s_header_value_start;
-          CALLBACK_DATA(header_field);
-          break;
-        }
-
-        if (ch == CR) {
-          parser->state = s_header_almost_done;
-          CALLBACK_DATA(header_field);
-          break;
-        }
-
-        if (ch == LF) {
-          parser->state = s_header_field_start;
+          UPDATE_STATE(s_header_value_discard_ws);
           CALLBACK_DATA(header_field);
           break;
         }
@@ -1351,27 +1442,27 @@ size_t http_parser_execute (http_parser *parser,
         goto error;
       }
 
-      case s_header_value_start:
-      {
+      case s_header_value_discard_ws:
         if (ch == ' ' || ch == '\t') break;
 
-        MARK(header_value);
-
-        parser->state = s_header_value;
-        parser->index = 0;
-
         if (ch == CR) {
-          parser->header_state = h_general;
-          parser->state = s_header_almost_done;
-          CALLBACK_DATA(header_value);
+          UPDATE_STATE(s_header_value_discard_ws_almost_done);
           break;
         }
 
         if (ch == LF) {
-          parser->state = s_header_field_start;
-          CALLBACK_DATA(header_value);
+          UPDATE_STATE(s_header_value_discard_lws);
           break;
         }
+
+        /* FALLTHROUGH */
+
+      case s_header_value_start:
+      {
+        MARK(header_value);
+
+        UPDATE_STATE(s_header_value);
+        parser->index = 0;
 
         c = LOWER(ch);
 
@@ -1391,7 +1482,7 @@ size_t http_parser_execute (http_parser *parser,
             break;
 
           case h_content_length:
-            if (!IS_NUM(ch)) {
+            if (UNLIKELY(!IS_NUM(ch))) {
               SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
               goto error;
             }
@@ -1406,9 +1497,15 @@ size_t http_parser_execute (http_parser *parser,
             /* looking for 'Connection: close' */
             } else if (c == 'c') {
               parser->header_state = h_matching_connection_close;
+            } else if (c == 'u') {
+              parser->header_state = h_matching_connection_upgrade;
             } else {
-              parser->header_state = h_general;
+              parser->header_state = h_matching_connection_token;
             }
+            break;
+
+          /* Multi-value `Connection` header */
+          case h_matching_connection_token_start:
             break;
 
           default:
@@ -1420,98 +1517,187 @@ size_t http_parser_execute (http_parser *parser,
 
       case s_header_value:
       {
-
-        if (ch == CR) {
-          parser->state = s_header_almost_done;
-          CALLBACK_DATA(header_value);
-          break;
-        }
-
-        if (ch == LF) {
-          parser->state = s_header_almost_done;
-          CALLBACK_DATA_NOADVANCE(header_value);
-          goto reexecute_byte;
-        }
-
-        c = LOWER(ch);
-
-        switch (parser->header_state) {
-          case h_general:
-            break;
-
-          case h_connection:
-          case h_transfer_encoding:
-            assert(0 && "Shouldn't get here.");
-            break;
-
-          case h_content_length:
-          {
-            uint64_t t;
-
-            if (ch == ' ') break;
-
-            if (!IS_NUM(ch)) {
-              SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
-              goto error;
-            }
-
-            t = parser->content_length;
-            t *= 10;
-            t += ch - '0';
-
-            /* Overflow? */
-            if (t < parser->content_length || t == ULLONG_MAX) {
-              SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
-              goto error;
-            }
-
-            parser->content_length = t;
+        const char* start = p;
+        enum header_states h_state = (enum header_states) parser->header_state;
+        for (; p != data + len; p++) {
+          ch = *p;
+          if (ch == CR) {
+            UPDATE_STATE(s_header_almost_done);
+            parser->header_state = h_state;
+            CALLBACK_DATA(header_value);
             break;
           }
 
-          /* Transfer-Encoding: chunked */
-          case h_matching_transfer_encoding_chunked:
-            parser->index++;
-            if (parser->index > sizeof(CHUNKED)-1
-                || c != CHUNKED[parser->index]) {
-              parser->header_state = h_general;
-            } else if (parser->index == sizeof(CHUNKED)-2) {
-              parser->header_state = h_transfer_encoding_chunked;
+          if (ch == LF) {
+            UPDATE_STATE(s_header_almost_done);
+            COUNT_HEADER_SIZE(p - start);
+            parser->header_state = h_state;
+            CALLBACK_DATA_NOADVANCE(header_value);
+            REEXECUTE();
+          }
+
+          c = LOWER(ch);
+
+          switch (h_state) {
+            case h_general:
+            {
+              const char* p_cr;
+              const char* p_lf;
+              size_t limit = data + len - p;
+
+              limit = MIN(limit, HTTP_MAX_HEADER_SIZE);
+
+              p_cr = (const char*) memchr(p, CR, limit);
+              p_lf = (const char*) memchr(p, LF, limit);
+              if (p_cr != NULL) {
+                if (p_lf != NULL && p_cr >= p_lf)
+                  p = p_lf;
+                else
+                  p = p_cr;
+              } else if (UNLIKELY(p_lf != NULL)) {
+                p = p_lf;
+              } else {
+                p = data + len;
+              }
+              --p;
+
+              break;
             }
-            break;
 
-          /* looking for 'Connection: keep-alive' */
-          case h_matching_connection_keep_alive:
-            parser->index++;
-            if (parser->index > sizeof(KEEP_ALIVE)-1
-                || c != KEEP_ALIVE[parser->index]) {
-              parser->header_state = h_general;
-            } else if (parser->index == sizeof(KEEP_ALIVE)-2) {
-              parser->header_state = h_connection_keep_alive;
+            case h_connection:
+            case h_transfer_encoding:
+              assert(0 && "Shouldn't get here.");
+              break;
+
+            case h_content_length:
+            {
+              uint64_t t;
+
+              if (ch == ' ') break;
+
+              if (UNLIKELY(!IS_NUM(ch))) {
+                SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+                parser->header_state = h_state;
+                goto error;
+              }
+
+              t = parser->content_length;
+              t *= 10;
+              t += ch - '0';
+
+              /* Overflow? Test against a conservative limit for simplicity. */
+              if (UNLIKELY((ULLONG_MAX - 10) / 10 < parser->content_length)) {
+                SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+                parser->header_state = h_state;
+                goto error;
+              }
+
+              parser->content_length = t;
+              break;
             }
-            break;
 
-          /* looking for 'Connection: close' */
-          case h_matching_connection_close:
-            parser->index++;
-            if (parser->index > sizeof(CLOSE)-1 || c != CLOSE[parser->index]) {
-              parser->header_state = h_general;
-            } else if (parser->index == sizeof(CLOSE)-2) {
-              parser->header_state = h_connection_close;
-            }
-            break;
+            /* Transfer-Encoding: chunked */
+            case h_matching_transfer_encoding_chunked:
+              parser->index++;
+              if (parser->index > sizeof(CHUNKED)-1
+                  || c != CHUNKED[parser->index]) {
+                h_state = h_general;
+              } else if (parser->index == sizeof(CHUNKED)-2) {
+                h_state = h_transfer_encoding_chunked;
+              }
+              break;
 
-          case h_transfer_encoding_chunked:
-          case h_connection_keep_alive:
-          case h_connection_close:
-            if (ch != ' ') parser->header_state = h_general;
-            break;
+            case h_matching_connection_token_start:
+              /* looking for 'Connection: keep-alive' */
+              if (c == 'k') {
+                h_state = h_matching_connection_keep_alive;
+              /* looking for 'Connection: close' */
+              } else if (c == 'c') {
+                h_state = h_matching_connection_close;
+              } else if (c == 'u') {
+                h_state = h_matching_connection_upgrade;
+              } else if (STRICT_TOKEN(c)) {
+                h_state = h_matching_connection_token;
+              } else if (c == ' ' || c == '\t') {
+                /* Skip lws */
+              } else {
+                h_state = h_general;
+              }
+              break;
 
-          default:
-            parser->state = s_header_value;
-            parser->header_state = h_general;
-            break;
+            /* looking for 'Connection: keep-alive' */
+            case h_matching_connection_keep_alive:
+              parser->index++;
+              if (parser->index > sizeof(KEEP_ALIVE)-1
+                  || c != KEEP_ALIVE[parser->index]) {
+                h_state = h_matching_connection_token;
+              } else if (parser->index == sizeof(KEEP_ALIVE)-2) {
+                h_state = h_connection_keep_alive;
+              }
+              break;
+
+            /* looking for 'Connection: close' */
+            case h_matching_connection_close:
+              parser->index++;
+              if (parser->index > sizeof(CLOSE)-1 || c != CLOSE[parser->index]) {
+                h_state = h_matching_connection_token;
+              } else if (parser->index == sizeof(CLOSE)-2) {
+                h_state = h_connection_close;
+              }
+              break;
+
+            /* looking for 'Connection: upgrade' */
+            case h_matching_connection_upgrade:
+              parser->index++;
+              if (parser->index > sizeof(UPGRADE) - 1 ||
+                  c != UPGRADE[parser->index]) {
+                h_state = h_matching_connection_token;
+              } else if (parser->index == sizeof(UPGRADE)-2) {
+                h_state = h_connection_upgrade;
+              }
+              break;
+
+            case h_matching_connection_token:
+              if (ch == ',') {
+                h_state = h_matching_connection_token_start;
+                parser->index = 0;
+              }
+              break;
+
+            case h_transfer_encoding_chunked:
+              if (ch != ' ') h_state = h_general;
+              break;
+
+            case h_connection_keep_alive:
+            case h_connection_close:
+            case h_connection_upgrade:
+              if (ch == ',') {
+                if (h_state == h_connection_keep_alive) {
+                  parser->flags |= F_CONNECTION_KEEP_ALIVE;
+                } else if (h_state == h_connection_close) {
+                  parser->flags |= F_CONNECTION_CLOSE;
+                } else if (h_state == h_connection_upgrade) {
+                  parser->flags |= F_CONNECTION_UPGRADE;
+                }
+                h_state = h_matching_connection_token_start;
+                parser->index = 0;
+              } else if (ch != ' ') {
+                h_state = h_matching_connection_token;
+              }
+              break;
+
+            default:
+              UPDATE_STATE(s_header_value);
+              h_state = h_general;
+              break;
+          }
         }
+        parser->header_state = h_state;
+
+        COUNT_HEADER_SIZE(p - start);
+
+        if (p == data + len)
+          --p;
         break;
       }
 
@@ -1519,8 +1705,18 @@ size_t http_parser_execute (http_parser *parser,
       {
         STRICT_CHECK(ch != LF);
 
-        parser->state = s_header_value_lws;
+        UPDATE_STATE(s_header_value_lws);
+        break;
+      }
 
+      case s_header_value_lws:
+      {
+        if (ch == ' ' || ch == '\t') {
+          UPDATE_STATE(s_header_value_start);
+          REEXECUTE();
+        }
+
+        /* finished the header */
         switch (parser->header_state) {
           case h_connection_keep_alive:
             parser->flags |= F_CONNECTION_KEEP_ALIVE;
@@ -1531,23 +1727,53 @@ size_t http_parser_execute (http_parser *parser,
           case h_transfer_encoding_chunked:
             parser->flags |= F_CHUNKED;
             break;
+          case h_connection_upgrade:
+            parser->flags |= F_CONNECTION_UPGRADE;
+            break;
           default:
             break;
         }
 
+        UPDATE_STATE(s_header_field_start);
+        REEXECUTE();
+      }
+
+      case s_header_value_discard_ws_almost_done:
+      {
+        STRICT_CHECK(ch != LF);
+        UPDATE_STATE(s_header_value_discard_lws);
         break;
       }
 
-      case s_header_value_lws:
+      case s_header_value_discard_lws:
       {
-        if (ch == ' ' || ch == '\t')
-          parser->state = s_header_value_start;
-        else
-        {
-          parser->state = s_header_field_start;
-          goto reexecute_byte;
+        if (ch == ' ' || ch == '\t') {
+          UPDATE_STATE(s_header_value_discard_ws);
+          break;
+        } else {
+          switch (parser->header_state) {
+            case h_connection_keep_alive:
+              parser->flags |= F_CONNECTION_KEEP_ALIVE;
+              break;
+            case h_connection_close:
+              parser->flags |= F_CONNECTION_CLOSE;
+              break;
+            case h_connection_upgrade:
+              parser->flags |= F_CONNECTION_UPGRADE;
+              break;
+            case h_transfer_encoding_chunked:
+              parser->flags |= F_CHUNKED;
+              break;
+            default:
+              break;
+          }
+
+          /* header value was empty */
+          MARK(header_value);
+          UPDATE_STATE(s_header_field_start);
+          CALLBACK_DATA_NOADVANCE(header_value);
+          REEXECUTE();
         }
-        break;
       }
 
       case s_headers_almost_done:
@@ -1556,16 +1782,18 @@ size_t http_parser_execute (http_parser *parser,
 
         if (parser->flags & F_TRAILING) {
           /* End of a chunked request */
-          parser->state = NEW_MESSAGE();
+          UPDATE_STATE(NEW_MESSAGE());
           CALLBACK_NOTIFY(message_complete);
           break;
         }
 
-        parser->state = s_headers_done;
+        UPDATE_STATE(s_headers_done);
 
         /* Set this here so that on_headers_complete() callbacks can see it */
         parser->upgrade =
-          (parser->flags & F_UPGRADE || parser->method == HTTP_CONNECT);
+          ((parser->flags & (F_UPGRADE | F_CONNECTION_UPGRADE)) ==
+           (F_UPGRADE | F_CONNECTION_UPGRADE) ||
+           parser->method == HTTP_CONNECT);
 
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we
@@ -1587,15 +1815,15 @@ size_t http_parser_execute (http_parser *parser,
 
             default:
               SET_ERRNO(HPE_CB_headers_complete);
-              return p - data; /* Error */
+              RETURN(p - data); /* Error */
           }
         }
 
         if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
-          return p - data;
+          RETURN(p - data);
         }
 
-        goto reexecute_byte;
+        REEXECUTE();
       }
 
       case s_headers_done:
@@ -1606,34 +1834,34 @@ size_t http_parser_execute (http_parser *parser,
 
         /* Exit, the rest of the connect is in a different protocol. */
         if (parser->upgrade) {
-          parser->state = NEW_MESSAGE();
+          UPDATE_STATE(NEW_MESSAGE());
           CALLBACK_NOTIFY(message_complete);
-          return (p - data) + 1;
+          RETURN((p - data) + 1);
         }
 
         if (parser->flags & F_SKIPBODY) {
-          parser->state = NEW_MESSAGE();
+          UPDATE_STATE(NEW_MESSAGE());
           CALLBACK_NOTIFY(message_complete);
         } else if (parser->flags & F_CHUNKED) {
           /* chunked encoding - ignore Content-Length header */
-          parser->state = s_chunk_size_start;
+          UPDATE_STATE(s_chunk_size_start);
         } else {
           if (parser->content_length == 0) {
             /* Content-Length header given but zero: Content-Length: 0\r\n */
-            parser->state = NEW_MESSAGE();
+            UPDATE_STATE(NEW_MESSAGE());
             CALLBACK_NOTIFY(message_complete);
           } else if (parser->content_length != ULLONG_MAX) {
             /* Content-Length header given and non-zero */
-            parser->state = s_body_identity;
+            UPDATE_STATE(s_body_identity);
           } else {
             if (parser->type == HTTP_REQUEST ||
                 !http_message_needs_eof(parser)) {
               /* Assume content-length 0 - read the next */
-              parser->state = NEW_MESSAGE();
+              UPDATE_STATE(NEW_MESSAGE());
               CALLBACK_NOTIFY(message_complete);
             } else {
               /* Read body until EOF */
-              parser->state = s_body_identity_eof;
+              UPDATE_STATE(s_body_identity_eof);
             }
           }
         }
@@ -1659,7 +1887,7 @@ size_t http_parser_execute (http_parser *parser,
         p += to_read - 1;
 
         if (parser->content_length == 0) {
-          parser->state = s_message_done;
+          UPDATE_STATE(s_message_done);
 
           /* Mimic CALLBACK_DATA_NOADVANCE() but with one extra byte.
            *
@@ -1671,7 +1899,7 @@ size_t http_parser_execute (http_parser *parser,
            * important for applications, but let's keep it for now.
            */
           CALLBACK_DATA_(body, p - body_mark + 1, p - data);
-          goto reexecute_byte;
+          REEXECUTE();
         }
 
         break;
@@ -1685,7 +1913,7 @@ size_t http_parser_execute (http_parser *parser,
         break;
 
       case s_message_done:
-        parser->state = NEW_MESSAGE();
+        UPDATE_STATE(NEW_MESSAGE());
         CALLBACK_NOTIFY(message_complete);
         break;
 
@@ -1695,13 +1923,13 @@ size_t http_parser_execute (http_parser *parser,
         assert(parser->flags & F_CHUNKED);
 
         unhex_val = unhex[(unsigned char)ch];
-        if (unhex_val == -1) {
+        if (UNLIKELY(unhex_val == -1)) {
           SET_ERRNO(HPE_INVALID_CHUNK_SIZE);
           goto error;
         }
 
         parser->content_length = unhex_val;
-        parser->state = s_chunk_size;
+        UPDATE_STATE(s_chunk_size);
         break;
       }
 
@@ -1712,7 +1940,7 @@ size_t http_parser_execute (http_parser *parser,
         assert(parser->flags & F_CHUNKED);
 
         if (ch == CR) {
-          parser->state = s_chunk_size_almost_done;
+          UPDATE_STATE(s_chunk_size_almost_done);
           break;
         }
 
@@ -1720,7 +1948,7 @@ size_t http_parser_execute (http_parser *parser,
 
         if (unhex_val == -1) {
           if (ch == ';' || ch == ' ') {
-            parser->state = s_chunk_parameters;
+            UPDATE_STATE(s_chunk_parameters);
             break;
           }
 
@@ -1732,8 +1960,8 @@ size_t http_parser_execute (http_parser *parser,
         t *= 16;
         t += unhex_val;
 
-        /* Overflow? */
-        if (t < parser->content_length || t == ULLONG_MAX) {
+        /* Overflow? Test against a conservative limit for simplicity. */
+        if (UNLIKELY((ULLONG_MAX - 16) / 16 < parser->content_length)) {
           SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
           goto error;
         }
@@ -1747,7 +1975,7 @@ size_t http_parser_execute (http_parser *parser,
         assert(parser->flags & F_CHUNKED);
         /* just ignore this shit. TODO check for overflow */
         if (ch == CR) {
-          parser->state = s_chunk_size_almost_done;
+          UPDATE_STATE(s_chunk_size_almost_done);
           break;
         }
         break;
@@ -1762,9 +1990,9 @@ size_t http_parser_execute (http_parser *parser,
 
         if (parser->content_length == 0) {
           parser->flags |= F_TRAILING;
-          parser->state = s_header_field_start;
+          UPDATE_STATE(s_header_field_start);
         } else {
-          parser->state = s_chunk_data;
+          UPDATE_STATE(s_chunk_data);
         }
         break;
       }
@@ -1786,7 +2014,7 @@ size_t http_parser_execute (http_parser *parser,
         p += to_read - 1;
 
         if (parser->content_length == 0) {
-          parser->state = s_chunk_data_almost_done;
+          UPDATE_STATE(s_chunk_data_almost_done);
         }
 
         break;
@@ -1796,7 +2024,7 @@ size_t http_parser_execute (http_parser *parser,
         assert(parser->flags & F_CHUNKED);
         assert(parser->content_length == 0);
         STRICT_CHECK(ch != CR);
-        parser->state = s_chunk_data_done;
+        UPDATE_STATE(s_chunk_data_done);
         CALLBACK_DATA(body);
         break;
 
@@ -1804,7 +2032,7 @@ size_t http_parser_execute (http_parser *parser,
         assert(parser->flags & F_CHUNKED);
         STRICT_CHECK(ch != LF);
         parser->nread = 0;
-        parser->state = s_chunk_size_start;
+        UPDATE_STATE(s_chunk_size_start);
         break;
 
       default:
@@ -1827,21 +2055,23 @@ size_t http_parser_execute (http_parser *parser,
   assert(((header_field_mark ? 1 : 0) +
           (header_value_mark ? 1 : 0) +
           (url_mark ? 1 : 0)  +
-          (body_mark ? 1 : 0)) <= 1);
+          (body_mark ? 1 : 0) +
+          (status_mark ? 1 : 0)) <= 1);
 
   CALLBACK_DATA_NOADVANCE(header_field);
   CALLBACK_DATA_NOADVANCE(header_value);
   CALLBACK_DATA_NOADVANCE(url);
   CALLBACK_DATA_NOADVANCE(body);
+  CALLBACK_DATA_NOADVANCE(status);
 
-  return len;
+  RETURN(len);
 
 error:
   if (HTTP_PARSER_ERRNO(parser) == HPE_OK) {
     SET_ERRNO(HPE_UNKNOWN);
   }
 
-  return (p - data);
+  RETURN(p - data);
 }
 
 
@@ -2067,7 +2297,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
   u->port = u->field_set = 0;
   s = is_connect ? s_req_server_start : s_req_spaces_before_url;
-  uf = old_uf = UF_MAX;
+  old_uf = UF_MAX;
 
   for (p = buf; p < buf + buflen; p++) {
     s = parse_url_char(s, *p);
@@ -2172,4 +2402,11 @@ http_parser_pause(http_parser *parser, int paused) {
 int
 http_body_is_final(const struct http_parser *parser) {
     return parser->state == s_message_done;
+}
+
+unsigned long
+http_parser_version(void) {
+  return HTTP_PARSER_VERSION_MAJOR * 0x10000 |
+         HTTP_PARSER_VERSION_MINOR * 0x00100 |
+         HTTP_PARSER_VERSION_PATCH * 0x00001;
 }

--- a/src/http_parser.h
+++ b/src/http_parser.h
@@ -24,8 +24,10 @@
 extern "C" {
 #endif
 
+/* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
-#define HTTP_PARSER_VERSION_MINOR 1
+#define HTTP_PARSER_VERSION_MINOR 4
+#define HTTP_PARSER_VERSION_PATCH 2
 
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
@@ -50,9 +52,16 @@ typedef unsigned __int64 uint64_t;
 # define HTTP_PARSER_STRICT 1
 #endif
 
-/* Maximium header size allowed */
-#define HTTP_MAX_HEADER_SIZE (80*1024)
-
+/* Maximium header size allowed. If the macro is not defined
+ * before including this header then the default is used. To
+ * change the maximum header size, define the macro in the build
+ * environment (e.g. -DHTTP_MAX_HEADER_SIZE=<value>). To remove
+ * the effective limit on the size of the header, define the macro
+ * to a very large number (e.g. -DHTTP_MAX_HEADER_SIZE=0x7fffffff)
+ */
+#ifndef HTTP_MAX_HEADER_SIZE
+# define HTTP_MAX_HEADER_SIZE (80*1024)
+#endif
 
 typedef struct http_parser http_parser;
 typedef struct http_parser_settings http_parser_settings;
@@ -67,7 +76,7 @@ typedef struct http_parser_settings http_parser_settings;
  * HEAD request which may contain 'Content-Length' or 'Transfer-Encoding:
  * chunked' headers that indicate the presence of a body.
  *
- * http_data_cb does not return data chunks. It will be call arbitrarally
+ * http_data_cb does not return data chunks. It will be called arbitrarily
  * many times for each string. E.G. you might get 10 callbacks for "on_url"
  * each providing just a few characters more data.
  */
@@ -108,6 +117,8 @@ typedef int (*http_cb) (http_parser*);
   /* RFC-5789 */                    \
   XX(24, PATCH,       PATCH)        \
   XX(25, PURGE,       PURGE)        \
+  /* CalDAV */                      \
+  XX(26, MKCALENDAR,  MKCALENDAR)   \
 
 enum http_method
   {
@@ -125,9 +136,10 @@ enum flags
   { F_CHUNKED               = 1 << 0
   , F_CONNECTION_KEEP_ALIVE = 1 << 1
   , F_CONNECTION_CLOSE      = 1 << 2
-  , F_TRAILING              = 1 << 3
-  , F_UPGRADE               = 1 << 4
-  , F_SKIPBODY              = 1 << 5
+  , F_CONNECTION_UPGRADE    = 1 << 3
+  , F_TRAILING              = 1 << 4
+  , F_UPGRADE               = 1 << 5
+  , F_SKIPBODY              = 1 << 6
   };
 
 
@@ -141,13 +153,13 @@ enum flags
                                                                      \
   /* Callback-related errors */                                      \
   XX(CB_message_begin, "the on_message_begin callback failed")       \
-  XX(CB_status_complete, "the on_status_complete callback failed")   \
   XX(CB_url, "the on_url callback failed")                           \
   XX(CB_header_field, "the on_header_field callback failed")         \
   XX(CB_header_value, "the on_header_value callback failed")         \
   XX(CB_headers_complete, "the on_headers_complete callback failed") \
   XX(CB_body, "the on_body callback failed")                         \
   XX(CB_message_complete, "the on_message_complete callback failed") \
+  XX(CB_status, "the on_status callback failed")                     \
                                                                      \
   /* Parsing-related errors */                                       \
   XX(INVALID_EOF_STATE, "stream ended at an unexpected time")        \
@@ -191,11 +203,11 @@ enum http_errno {
 
 struct http_parser {
   /** PRIVATE **/
-  unsigned char type : 2;     /* enum http_parser_type */
-  unsigned char flags : 6;    /* F_* values from 'flags' enum; semi-public */
-  unsigned char state;        /* enum state from http_parser.c */
-  unsigned char header_state; /* enum header_state from http_parser.c */
-  unsigned char index;        /* index into current matcher */
+  unsigned int type : 2;         /* enum http_parser_type */
+  unsigned int flags : 6;        /* F_* values from 'flags' enum; semi-public */
+  unsigned int state : 8;        /* enum state from http_parser.c */
+  unsigned int header_state : 8; /* enum header_state from http_parser.c */
+  unsigned int index : 8;        /* index into current matcher */
 
   uint32_t nread;          /* # bytes read in various scenarios */
   uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */
@@ -203,16 +215,16 @@ struct http_parser {
   /** READ-ONLY **/
   unsigned short http_major;
   unsigned short http_minor;
-  unsigned short status_code; /* responses only */
-  unsigned char method;       /* requests only */
-  unsigned char http_errno : 7;
+  unsigned int status_code : 16; /* responses only */
+  unsigned int method : 8;       /* requests only */
+  unsigned int http_errno : 7;
 
   /* 1 = Upgrade header was present and the parser has exited because of that.
    * 0 = No upgrade header present.
    * Should be checked when http_parser_execute() returns in addition to
    * error checking.
    */
-  unsigned char upgrade : 1;
+  unsigned int upgrade : 1;
 
   /** PUBLIC **/
   void *data; /* A pointer to get hook to the "connection" or "socket" object */
@@ -222,7 +234,7 @@ struct http_parser {
 struct http_parser_settings {
   http_cb      on_message_begin;
   http_data_cb on_url;
-  http_cb      on_status_complete;
+  http_data_cb on_status;
   http_data_cb on_header_field;
   http_data_cb on_header_value;
   http_cb      on_headers_complete;
@@ -261,9 +273,23 @@ struct http_parser_url {
 };
 
 
+/* Returns the library version. Bits 16-23 contain the major version number,
+ * bits 8-15 the minor version number and bits 0-7 the patch level.
+ * Usage example:
+ *
+ *   unsigned long version = http_parser_version();
+ *   unsigned major = (version >> 16) & 255;
+ *   unsigned minor = (version >> 8) & 255;
+ *   unsigned patch = version & 255;
+ *   printf("http_parser v%u.%u.%u\n", major, minor, patch);
+ */
+unsigned long http_parser_version(void);
+
 void http_parser_init(http_parser *parser, enum http_parser_type type);
 
 
+/* Executes the parser. Returns number of parsed bytes. Sets
+ * `parser->http_errno` on error. */
 size_t http_parser_execute(http_parser *parser,
                            const http_parser_settings *settings,
                            const char *data,

--- a/src/main.h
+++ b/src/main.h
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <math.h>
-#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <stdarg.h>
@@ -17,7 +16,6 @@
 #include <signal.h>
 #include <time.h>
 #include <unistd.h>
-#include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/uio.h>
 
@@ -49,9 +47,8 @@ static int response_body(http_parser *, const char *, size_t);
 
 static uint64_t time_us();
 
-static char *extract_url_part(char *, struct http_parser_url *, enum http_parser_url_fields);
-
-static int parse_args(struct config *, char **, char **, int, char **);
+static int parse_args(struct config *, char **, struct http_parser_url *, char **, int, char **);
+static char *copy_url_part(char *, struct http_parser_url *, enum http_parser_url_fields);
 static void print_stats_header();
 static void print_stats(char *, stats *, char *(*)(long double));
 static void print_stats_latency(stats *);

--- a/src/net.c
+++ b/src/net.c
@@ -17,7 +17,7 @@ status sock_close(connection *c) {
 status sock_read(connection *c, size_t *n) {
     ssize_t r = read(c->fd, c->buf, sizeof(c->buf));
     *n = (size_t) r;
-    return r > 0 ? OK : ERROR;
+    return r >= 0 ? OK : ERROR;
 }
 
 status sock_write(connection *c, char *buf, size_t len, size_t *n) {

--- a/src/net.h
+++ b/src/net.h
@@ -1,9 +1,9 @@
 #ifndef NET_H
 #define NET_H
 
+#include "config.h"
 #include <stdint.h>
 #include <openssl/ssl.h>
-
 #include "wrk.h"
 
 typedef enum {

--- a/src/script.c
+++ b/src/script.c
@@ -5,6 +5,7 @@
 #include "script.h"
 #include "http_parser.h"
 #include "stats.h"
+#include "zmalloc.h"
 
 typedef struct {
     char *name;
@@ -12,76 +13,147 @@ typedef struct {
     void *value;
 } table_field;
 
+static int script_addr_tostring(lua_State *);
+static int script_addr_gc(lua_State *);
 static int script_stats_len(lua_State *);
 static int script_stats_get(lua_State *);
-static void set_fields(lua_State *, int index, const table_field *);
+static int script_thread_index(lua_State *);
+static int script_thread_newindex(lua_State *);
+static int script_wrk_lookup(lua_State *);
+static int script_wrk_connect(lua_State *);
 
-static const struct luaL_reg statslib[] = {
-    { "__index", script_stats_get },
-    { "__len",   script_stats_len },
-    { NULL,      NULL             }
+static void set_fields(lua_State *, int index, const table_field *);
+static void set_string(lua_State *, int, char *, char *, size_t);
+static char *get_url_part(char *, struct http_parser_url *, enum http_parser_url_fields, size_t *);
+
+static const struct luaL_reg addrlib[] = {
+    { "__tostring", script_addr_tostring   },
+    { "__gc"    ,   script_addr_gc         },
+    { NULL,         NULL                   }
 };
 
-lua_State *script_create(char *scheme, char *host, char *port, char *path) {
+static const struct luaL_reg statslib[] = {
+    { "__index",    script_stats_get       },
+    { "__len",      script_stats_len       },
+    { NULL,         NULL                   }
+};
+
+static const struct luaL_reg threadlib[] = {
+    { "__index",    script_thread_index    },
+    { "__newindex", script_thread_newindex },
+    { NULL,         NULL                   }
+};
+
+lua_State *script_create(char *file, char *url, char **headers) {
     lua_State *L = luaL_newstate();
     luaL_openlibs(L);
-    luaL_dostring(L, "wrk = require \"wrk\"");
+    (void) luaL_dostring(L, "wrk = require \"wrk\"");
 
+    luaL_newmetatable(L, "wrk.addr");
+    luaL_register(L, NULL, addrlib);
     luaL_newmetatable(L, "wrk.stats");
     luaL_register(L, NULL, statslib);
-    lua_pop(L, 1);
+    luaL_newmetatable(L, "wrk.thread");
+    luaL_register(L, NULL, threadlib);
+
+    struct http_parser_url parts = {};
+    script_parse_url(url, &parts);
+    char *path = "/";
+    size_t len = 0;
+
+    if (parts.field_set & (1 << UF_PATH)) {
+        path = &url[parts.field_data[UF_PATH].off];
+    }
 
     const table_field fields[] = {
-        { "scheme", LUA_TSTRING, scheme },
-        { "host",   LUA_TSTRING, host   },
-        { "port",   LUA_TSTRING, port   },
-        { "path",   LUA_TSTRING, path   },
-        { NULL,     0,           NULL   },
+        { "lookup",  LUA_TFUNCTION, script_wrk_lookup  },
+        { "connect", LUA_TFUNCTION, script_wrk_connect },
+        { "path",    LUA_TSTRING,   path               },
+        { NULL,      0,             NULL               },
     };
 
     lua_getglobal(L, "wrk");
-    set_fields(L, 1, fields);
-    lua_pop(L, 1);
 
-    return L;
-}
+    set_string(L, 4, "scheme", get_url_part(url, &parts, UF_SCHEMA, &len), len);
+    set_string(L, 4, "host",   get_url_part(url, &parts, UF_HOST,   &len), len);
+    set_string(L, 4, "port",   get_url_part(url, &parts, UF_PORT,   &len), len);
+    set_fields(L, 4, fields);
 
-void script_headers(lua_State *L, char **headers) {
-    lua_getglobal(L, "wrk");
-    lua_getfield(L, 1, "headers");
+    lua_getfield(L, 4, "headers");
     for (char **h = headers; *h; h++) {
         char *p = strchr(*h, ':');
         if (p && p[1] == ' ') {
             lua_pushlstring(L, *h, p - *h);
             lua_pushstring(L, p + 2);
-            lua_settable(L, 2);
+            lua_settable(L, 5);
         }
     }
-    lua_pop(L, 2);
+    lua_pop(L, 5);
+
+    if (file && luaL_dofile(L, file)) {
+        const char *cause = lua_tostring(L, -1);
+        fprintf(stderr, "%s: %s\n", file, cause);
+    }
+
+    return L;
 }
 
-void script_init(lua_State *L, char *script, int argc, char **argv) {
-    if (script && luaL_dofile(L, script)) {
-        const char *cause = lua_tostring(L, -1);
-        fprintf(stderr, "%s: %s\n", script, cause);
-    }
+bool script_resolve(lua_State *L, char *host, char *service) {
+    lua_getglobal(L, "wrk");
 
-    lua_getglobal(L, "init");
-    lua_newtable(L);
+    lua_getfield(L, -1, "resolve");
+    lua_pushstring(L, host);
+    lua_pushstring(L, service);
+    lua_pcall(L, 2, 0, 0);
+
+    lua_getfield(L, -1, "addrs");
+    size_t count = lua_objlen(L, -1);
+    lua_pop(L, 2);
+    return count > 0;
+}
+
+void script_push_thread(lua_State *L, thread *t) {
+    thread **ptr = (thread **) lua_newuserdata(L, sizeof(thread **));
+    *ptr = t;
+    luaL_getmetatable(L, "wrk.thread");
+    lua_setmetatable(L, -2);
+}
+
+void script_init(lua_State *L, thread *t, int argc, char **argv) {
+    lua_getglobal(t->L, "wrk");
+
+    script_push_thread(t->L, t);
+    lua_setfield(t->L, -2, "thread");
+
+    lua_getglobal(L, "wrk");
+    lua_getfield(L, -1, "setup");
+    script_push_thread(L, t);
+    lua_pcall(L, 1, 0, 0);
+    lua_pop(L, 1);
+
+    lua_getfield(t->L, -1, "init");
+    lua_newtable(t->L);
     for (int i = 0; i < argc; i++) {
-        lua_pushstring(L, argv[i]);
-        lua_rawseti(L, 2, i);
+        lua_pushstring(t->L, argv[i]);
+        lua_rawseti(t->L, -2, i);
     }
-    lua_call(L, 1, 0);
+    lua_pcall(t->L, 1, 0, 0);
+    lua_pop(t->L, 1);
 }
 
 void script_request(lua_State *L, char **buf, size_t *len) {
+    int pop = 1;
     lua_getglobal(L, "request");
-    lua_call(L, 0, 1);
-    const char *str = lua_tolstring(L, 1, len);
+    if (!lua_isfunction(L, -1)) {
+        lua_getglobal(L, "wrk");
+        lua_getfield(L, -1, "request");
+        pop += 2;
+    }
+    lua_pcall(L, 0, 1, 0);
+    const char *str = lua_tolstring(L, -1, len);
     *buf = realloc(*buf, *len);
     memcpy(*buf, str, *len);
-    lua_pop(L, 1);
+    lua_pop(L, pop);
 }
 
 void script_response(lua_State *L, int status, buffer *headers, buffer *body) {
@@ -96,33 +168,29 @@ void script_response(lua_State *L, int status, buffer *headers, buffer *body) {
     }
 
     lua_pushlstring(L, body->buffer, body->cursor - body->buffer);
-    lua_call(L, 3, 0);
+    lua_pcall(L, 3, 0, 0);
 
     buffer_reset(headers);
     buffer_reset(body);
 }
 
+bool script_is_function(lua_State *L, char *name) {
+    lua_getglobal(L, name);
+    bool is_function = lua_isfunction(L, -1);
+    lua_pop(L, 1);
+    return is_function;
+}
+
 bool script_is_static(lua_State *L) {
-    lua_getglobal(L, "wrk");
-    lua_getfield(L, 1, "request");
-    lua_getglobal(L, "request");
-    bool is_static = lua_equal(L, 2, 3);
-    lua_pop(L, 3);
-    return is_static;
+    return !script_is_function(L, "request");
 }
 
 bool script_want_response(lua_State *L) {
-    lua_getglobal(L, "response");
-    bool defined = lua_type(L, 1) == LUA_TFUNCTION;
-    lua_pop(L, 1);
-    return defined;
+    return script_is_function(L, "response");
 }
 
 bool script_has_done(lua_State *L) {
-    lua_getglobal(L, "done");
-    bool defined = lua_type(L, 1) == LUA_TFUNCTION;
-    lua_pop(L, 1);
-    return defined;
+    return script_is_function(L, "done");
 }
 
 void script_header_done(lua_State *L, luaL_Buffer *buffer) {
@@ -177,7 +245,7 @@ void script_done(lua_State *L, stats *latency, stats *requests) {
     luaL_getmetatable(L, "wrk.stats");
     lua_setmetatable(L, 5);
 
-    lua_call(L, 3, 0);
+    lua_pcall(L, 3, 0, 0);
     lua_pop(L, 1);
 }
 
@@ -220,6 +288,48 @@ size_t script_verify_request(lua_State *L) {
     }
 
     return count;
+}
+
+static struct addrinfo *checkaddr(lua_State *L) {
+    struct addrinfo *addr = luaL_checkudata(L, -1, "wrk.addr");
+    luaL_argcheck(L, addr != NULL, 1, "`addr' expected");
+    return addr;
+}
+
+void script_addr_copy(struct addrinfo *src, struct addrinfo *dst) {
+    *dst = *src;
+    dst->ai_addr = zmalloc(src->ai_addrlen);
+    memcpy(dst->ai_addr, src->ai_addr, src->ai_addrlen);
+}
+
+struct addrinfo *script_addr_clone(lua_State *L, struct addrinfo *addr) {
+    struct addrinfo *udata = lua_newuserdata(L, sizeof(*udata));
+    luaL_getmetatable(L, "wrk.addr");
+    lua_setmetatable(L, -2);
+    script_addr_copy(addr, udata);
+    return udata;
+}
+
+static int script_addr_tostring(lua_State *L) {
+    struct addrinfo *addr = checkaddr(L);
+    char host[NI_MAXHOST];
+    char service[NI_MAXSERV];
+
+    int flags = NI_NUMERICHOST | NI_NUMERICSERV;
+    int rc = getnameinfo(addr->ai_addr, addr->ai_addrlen, host, NI_MAXHOST, service, NI_MAXSERV, flags);
+    if (rc != 0) {
+        const char *msg = gai_strerror(rc);
+        return luaL_error(L, "addr tostring failed %s", msg);
+    }
+
+    lua_pushfstring(L, "%s:%s", host, service);
+    return 1;
+}
+
+static int script_addr_gc(lua_State *L) {
+    struct addrinfo *addr = checkaddr(L);
+    zfree(addr->ai_addr);
+    return 0;
 }
 
 static stats *checkstats(lua_State *L) {
@@ -269,10 +379,159 @@ static int script_stats_len(lua_State *L) {
     return 1;
 }
 
+static thread *checkthread(lua_State *L) {
+    thread **t = luaL_checkudata(L, 1, "wrk.thread");
+    luaL_argcheck(L, t != NULL, 1, "`thread' expected");
+    return *t;
+}
+
+static int script_thread_get(lua_State *L) {
+    thread *t = checkthread(L);
+    const char *key = lua_tostring(L, -1);
+    lua_getglobal(t->L, key);
+    script_copy_value(t->L, L, -1);
+    lua_pop(t->L, 1);
+    return 1;
+}
+
+static int script_thread_set(lua_State *L) {
+    thread *t = checkthread(L);
+    const char *name = lua_tostring(L, -2);
+    script_copy_value(L, t->L, -1);
+    lua_setglobal(t->L, name);
+    return 0;
+}
+
+static int script_thread_stop(lua_State *L) {
+    thread *t = checkthread(L);
+    aeStop(t->loop);
+    return 0;
+}
+
+static int script_thread_index(lua_State *L) {
+    thread *t = checkthread(L);
+    const char *key = lua_tostring(L, 2);
+    if (!strcmp("get",  key)) lua_pushcfunction(L, script_thread_get);
+    if (!strcmp("set",  key)) lua_pushcfunction(L, script_thread_set);
+    if (!strcmp("stop", key)) lua_pushcfunction(L, script_thread_stop);
+    if (!strcmp("addr", key)) script_addr_clone(L, t->addr);
+    return 1;
+}
+
+static int script_thread_newindex(lua_State *L) {
+    thread *t = checkthread(L);
+    const char *key = lua_tostring(L, -2);
+    if (!strcmp("addr", key)) {
+        struct addrinfo *addr = checkaddr(L);
+        if (t->addr) zfree(t->addr->ai_addr);
+        t->addr = zrealloc(t->addr, sizeof(*addr));
+        script_addr_copy(addr, t->addr);
+    } else {
+        luaL_error(L, "cannot set '%s' on thread", luaL_typename(L, -1));
+    }
+    return 0;
+}
+
+static int script_wrk_lookup(lua_State *L) {
+    struct addrinfo *addrs;
+    struct addrinfo hints = {
+        .ai_family   = AF_UNSPEC,
+        .ai_socktype = SOCK_STREAM
+    };
+    int rc, index = 1;
+
+    const char *host    = lua_tostring(L, -2);
+    const char *service = lua_tostring(L, -1);
+
+    if ((rc = getaddrinfo(host, service, &hints, &addrs)) != 0) {
+        const char *msg = gai_strerror(rc);
+        fprintf(stderr, "unable to resolve %s:%s %s\n", host, service, msg);
+        exit(1);
+    }
+
+    lua_newtable(L);
+    for (struct addrinfo *addr = addrs; addr != NULL; addr = addr->ai_next) {
+        script_addr_clone(L, addr);
+        lua_rawseti(L, -2, index++);
+    }
+
+    freeaddrinfo(addrs);
+    return 1;
+}
+
+static int script_wrk_connect(lua_State *L) {
+    struct addrinfo *addr = checkaddr(L);
+    int fd, connected = 0;
+    if ((fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol)) != -1) {
+        connected = connect(fd, addr->ai_addr, addr->ai_addrlen) == 0;
+        close(fd);
+    }
+    lua_pushboolean(L, connected);
+    return 1;
+}
+
+void script_copy_value(lua_State *src, lua_State *dst, int index) {
+    switch (lua_type(src, index)) {
+        case LUA_TBOOLEAN:
+            lua_pushboolean(dst, lua_toboolean(src, index));
+            break;
+        case LUA_TNIL:
+            lua_pushnil(dst);
+            break;
+        case LUA_TNUMBER:
+            lua_pushnumber(dst, lua_tonumber(src, index));
+            break;
+        case LUA_TSTRING:
+            lua_pushstring(dst, lua_tostring(src, index));
+            break;
+        case LUA_TTABLE:
+            lua_newtable(dst);
+            lua_pushnil(src);
+            while (lua_next(src, index - 1)) {
+                script_copy_value(src, dst, -1);
+                script_copy_value(src, dst, -2);
+                lua_settable(dst, -3);
+                lua_pop(src, 1);
+            }
+            lua_pop(src, 1);
+            break;
+        default:
+            luaL_error(src, "cannot transfer '%s' to thread", luaL_typename(src, index));
+    }
+}
+
+int script_parse_url(char *url, struct http_parser_url *parts) {
+    if (!http_parser_parse_url(url, strlen(url), 0, parts)) {
+        if (!(parts->field_set & (1 << UF_SCHEMA))) return 0;
+        if (!(parts->field_set & (1 << UF_HOST)))   return 0;
+        return 1;
+    }
+    return 0;
+}
+
+static char *get_url_part(char *url, struct http_parser_url *parts, enum http_parser_url_fields field, size_t *len) {
+    char *value = NULL;
+    if (parts->field_set & (1 << field)) {
+        value = &url[parts->field_data[field].off];
+        *len  = parts->field_data[field].len;
+    }
+    return value;
+}
+
+static void set_string(lua_State *L, int index, char *field, char *value, size_t len) {
+    if (value != NULL) {
+        lua_pushlstring(L, value, len);
+        lua_setfield(L, index, field);
+    }
+}
+
 static void set_fields(lua_State *L, int index, const table_field *fields) {
     for (int i = 0; fields[i].name; i++) {
         table_field f = fields[i];
         switch (f.value == NULL ? LUA_TNIL : f.type) {
+            case LUA_TFUNCTION:
+                lua_pushcfunction(L, (lua_CFunction) f.value);
+                break;
             case LUA_TNUMBER:
                 lua_pushinteger(L, *((lua_Integer *) f.value));
                 break;

--- a/src/script.h
+++ b/src/script.h
@@ -5,28 +5,29 @@
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
+#include <unistd.h>
 #include "stats.h"
+#include "wrk.h"
 
-typedef struct {
-    char  *buffer;
-    size_t length;
-    char  *cursor;
-} buffer;
+lua_State *script_create(char *, char *, char **);
 
-lua_State *script_create(char *, char *, char *, char *);
-void script_headers(lua_State *, char **);
-size_t script_verify_request(lua_State *L);
-
-void script_init(lua_State *, char *, int, char **);
+bool script_resolve(lua_State *, char *, char *);
+void script_setup(lua_State *, thread *);
 void script_done(lua_State *, stats *, stats *);
+
+void script_init(lua_State *, thread *, int, char **);
 void script_request(lua_State *, char **, size_t *);
 void script_response(lua_State *, int, buffer *, buffer *);
+size_t script_verify_request(lua_State *L);
 
 bool script_is_static(lua_State *);
 bool script_want_response(lua_State *L);
 bool script_has_done(lua_State *L);
 void script_summary(lua_State *, uint64_t, uint64_t, uint64_t);
 void script_errors(lua_State *, errors *);
+
+void script_copy_value(lua_State *, lua_State *, int);
+int script_parse_url(char *, struct http_parser_url *);
 
 void buffer_append(buffer *, const char *, size_t);
 void buffer_reset(buffer *);

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -5,13 +5,15 @@
 #include <pthread.h>
 #include <inttypes.h>
 #include <sys/types.h>
+#include <netdb.h>
+#include <sys/socket.h>
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <lua.h>
 
 #include "stats.h"
 #include "ae.h"
-#include "script.h"
 #include "http_parser.h"
 #include "hdr_histogram.h"
 
@@ -26,6 +28,7 @@
 typedef struct {
     pthread_t thread;
     aeEventLoop *loop;
+    struct addrinfo *addr;
     uint64_t connections;
     int interval;
     uint64_t stop_at;
@@ -42,6 +45,12 @@ typedef struct {
     errors errors;
     struct connection *cs;
 } thread;
+
+typedef struct {
+    char  *buffer;
+    size_t length;
+    char  *cursor;
+} buffer;
 
 typedef struct connection {
     thread *thread;


### PR DESCRIPTION
Is below of interest for wrk2? If so, I can spend time
cherry-picking individual commits from upstream, 
rather than this large commit if that is preferred. 


Backporting non-statistics related changes
which occurred in wrk since wrk2 forked.
Primary need was the lua scripting changes
making it possible to set each threads ip
address from lua.

Upstream scripting changes

* eb165ce prepare wrk 4.0.0 release
* 57f3b33 simplify script state setup
* 9b84d3e add script setup() and thread methods
* 6f0aa32 move address resolution into lua
* 93348e2 add CHANGES file and simplify script init

HTTP parser

* 6c15549 update http parser to 2.4.2
* 522ec60 pass EOF through to parser