### PR TITLE
Re-connect when peer closes the connection

### DIFF
--- a/src/ae_epoll.c
+++ b/src/ae_epoll.c
@@ -73,7 +73,7 @@ static int aeApiAddEvent(aeEventLoop *eventLoop, int fd, int mask) {
 
     ee.events = 0;
     mask |= eventLoop->events[fd].mask; /* Merge old events */
-    if (mask & AE_READABLE) ee.events |= EPOLLIN;
+    if (mask & AE_READABLE) ee.events |= (EPOLLIN|EPOLLHUP|EPOLLRDHUP);
     if (mask & AE_WRITABLE) ee.events |= EPOLLOUT;
     ee.data.u64 = 0; /* avoid valgrind warning */
     ee.data.fd = fd;

--- a/src/ae_epoll.c
+++ b/src/ae_epoll.c
@@ -114,7 +114,7 @@ static int aeApiPoll(aeEventLoop *eventLoop, struct timeval *tvp) {
             int mask = 0;
             struct epoll_event *e = state->events+j;
 
-            if (e->events & EPOLLIN) mask |= AE_READABLE;
+            if (e->events & (EPOLLIN | EPOLLRDHUP | EPOLLHUP)) mask |= AE_READABLE;
             if (e->events & EPOLLOUT) mask |= AE_WRITABLE;
             if (e->events & EPOLLERR) mask |= AE_WRITABLE;
             if (e->events & EPOLLHUP) mask |= AE_WRITABLE;

--- a/src/net.c
+++ b/src/net.c
@@ -17,7 +17,7 @@ status sock_close(connection *c) {
 status sock_read(connection *c, size_t *n) {
     ssize_t r = read(c->fd, c->buf, sizeof(c->buf));
     *n = (size_t) r;
-    return r >= 0 ? OK : ERROR;
+    return r > 0 ? OK : ERROR;
 }
 
 status sock_write(connection *c, char *buf, size_t len, size_t *n) {

--- a/src/net.c
+++ b/src/net.c
@@ -17,6 +17,7 @@ status sock_close(connection *c) {
 status sock_read(connection *c, size_t *n) {
     ssize_t r = read(c->fd, c->buf, sizeof(c->buf));
     *n = (size_t) r;
+    if (r == 0) return READ_EOF;
     return r > 0 ? OK : ERROR;
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -9,7 +9,8 @@
 typedef enum {
     OK,
     ERROR,
-    RETRY
+    RETRY,
+    READ_EOF
 } status;
 
 struct sock {

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -650,18 +650,21 @@ static void socket_writeable(aeEventLoop *loop, int fd, void *data, int mask) {
 static void socket_readable(aeEventLoop *loop, int fd, void *data, int mask) {
     connection *c = data;
     size_t n;
+    int read_status = OK;
 
     do {
-        switch (sock.read(c, &n)) {
+        switch (read_status = sock.read(c, &n)) {
             case OK:    break;
             case ERROR: goto error;
             case RETRY: return;
+            case READ_EOF: break;
         }
 
         if (http_parser_execute(&c->parser, &parser_settings, c->buf, n) != n) goto error;
         c->thread->bytes += n;
     } while (n == RECVBUF && sock.readable(c) > 0);
 
+    if (read_status == READ_EOF) goto error;
     return;
 
   error:


### PR DESCRIPTION
It was accumulating close-wait sockets for when peer closed connections, the code seemed to want to re-connect but was missing some corner cases (wasn't re-producible except under high load). This fixes it to reconnect (verified that it doesn't accumulate close-waits under the same load, same env).
