### PR TITLE
support for getting current time in LUA scripts time_us()

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -21,6 +21,7 @@ static int script_thread_index(lua_State *);
 static int script_thread_newindex(lua_State *);
 static int script_wrk_lookup(lua_State *);
 static int script_wrk_connect(lua_State *);
+static int script_wrk_time_us(lua_State *);
 
 static void set_fields(lua_State *, int, const table_field *);
 static void set_field(lua_State *, int, char *, int);
@@ -67,6 +68,7 @@ lua_State *script_create(char *file, char *url, char **headers) {
     const table_field fields[] = {
         { "lookup",  LUA_TFUNCTION, script_wrk_lookup  },
         { "connect", LUA_TFUNCTION, script_wrk_connect },
+        { "time_us", LUA_TFUNCTION, script_wrk_time_us },
         { "path",    LUA_TSTRING,   path               },
         { NULL,      0,             NULL               },
     };
@@ -466,6 +468,14 @@ static int script_wrk_connect(lua_State *L) {
         close(fd);
     }
     lua_pushboolean(L, connected);
+    return 1;
+}
+
+static int script_wrk_time_us(lua_State *L) {	/* dMan */
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    uint64_t now = (tv.tv_sec * 1000000) + tv.tv_usec;
+    lua_pushnumber(L, now);
     return 1;
 }
 

--- a/src/script.c
+++ b/src/script.c
@@ -471,7 +471,7 @@ static int script_wrk_connect(lua_State *L) {
     return 1;
 }
 
-static int script_wrk_time_us(lua_State *L) {	/* dMan */
+static int script_wrk_time_us(lua_State *L) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     uint64_t now = (tv.tv_sec * 1000000) + tv.tv_usec;


### PR DESCRIPTION
Please consider adding support for getting current time in LUA scripts, so that wrk2 is more self-contained and there is no need for external LUA scripts/modules for getting time.