### PR TITLE
Fix hostname issue for connecting to AWS (and other web services)

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -6,7 +6,7 @@
 
 #include "net.h"
 
-status sock_connect(connection *c) {
+status sock_connect(connection *c, char *host) {
     return OK;
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -13,14 +13,14 @@ typedef enum {
 } status;
 
 struct sock {
-    status ( *connect)(connection *);
+    status ( *connect)(connection *, char *);
     status (   *close)(connection *);
     status (    *read)(connection *, size_t *);
     status (   *write)(connection *, char *, size_t, size_t *);
     size_t (*readable)(connection *);
 };
 
-status sock_connect(connection *);
+status sock_connect(connection *, char *);
 status sock_close(connection *);
 status sock_read(connection *, size_t *);
 status sock_write(connection *, char *, size_t, size_t *);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -49,9 +49,10 @@ SSL_CTX *ssl_init() {
     return ctx;
 }
 
-status ssl_connect(connection *c) {
+status ssl_connect(connection *c, char *host) {
     int r;
     SSL_set_fd(c->ssl, c->fd);
+    SSL_set_tlsext_host_name(c->ssl, host);
     if ((r = SSL_connect(c->ssl)) != 1) {
         switch (SSL_get_error(c->ssl, r)) {
             case SSL_ERROR_WANT_READ:  return RETRY;

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -5,7 +5,7 @@
 
 SSL_CTX *ssl_init();
 
-status ssl_connect(connection *);
+status ssl_connect(connection *, char *);
 status ssl_close(connection *);
 status ssl_read(connection *, size_t *);
 status ssl_write(connection *, char *, size_t, size_t *);

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -21,6 +21,7 @@ static struct config {
     bool     u_latency;
     bool     dynamic;
     bool     record_all_responses;
+    char    *host;
     char    *script;
     SSL_CTX *ctx;
 } cfg;
@@ -99,7 +100,9 @@ int main(int argc, char **argv) {
         sock.write    = ssl_write;
         sock.readable = ssl_readable;
     }
-
+	
+    cfg.host = host;
+	
     signal(SIGPIPE, SIG_IGN);
     signal(SIGINT,  SIG_IGN);
 
@@ -570,7 +573,7 @@ static int response_complete(http_parser *parser) {
 static void socket_connected(aeEventLoop *loop, int fd, void *data, int mask) {
     connection *c = data;
 
-    switch (sock.connect(c)) {
+    switch (sock.connect(c, cfg.host)) {
         case OK:    break;
         case ERROR: goto error;
         case RETRY: return;


### PR DESCRIPTION
This is a patch that was included into wrk awhile back. Essentially AWS and some others (including google web services) requires SNI. See more details here:
https://forums.aws.amazon.com/thread.jspa?threadID=193615

With this fix you'll be able to use wrk2 with API Gateway and other services.