### PR TITLE
Adding lua script to output results & percentile latency in JSON format

### DIFF
--- a/scripts/json.lua
+++ b/scripts/json.lua
@@ -1,0 +1,25 @@
+-- example reporting script which demonstrates a custom
+-- done() function that prints results as JSON
+
+done = function(summary, latency, requests)
+   io.write("\nJSON Output:\n")
+   io.write("{\n")
+   io.write(string.format("\t\"requests\": %d,\n", summary.requests))
+   io.write(string.format("\t\"duration_in_microseconds\": %0.2f,\n", summary.duration))
+   io.write(string.format("\t\"bytes\": %d,\n", summary.bytes))
+   io.write(string.format("\t\"requests_per_sec\": %0.2f,\n", (summary.requests/summary.duration)*1e6))
+   io.write(string.format("\t\"bytes_transfer_per_sec\": %0.2f,\n", (summary.bytes/summary.duration)*1e6))
+   
+   io.write("\t\"latency_distribution\": [\n")
+   for _, p in pairs({ 50, 75, 90, 99, 99.9, 99.99, 99.999, 100 }) do
+      io.write("\t\t{\n")
+      n = latency:percentile(p)
+      io.write(string.format("\t\t\t\"percentile\": %g,\n\t\t\t\"latency_in_microseconds\": %d\n", p, n))
+      if p == 100 then 
+          io.write("\t\t}\n")
+      else 
+          io.write("\t\t},\n")
+      end
+   end
+   io.write("\t]\n}\n")
+end


### PR DESCRIPTION
This pull request will add a new file json.lua to scripts directory. This can be used to output results in JSON format as shown below

```
$ ./wrk -c 50 -t 2 -R 50 -d 15s -s scripts/json.lua -L http://myserverip
Running 15s test @ http://myserverip
  2 threads and 50 connections
  Thread calibration: mean lat.: 15.027ms, rate sampling interval: 38ms
  Thread calibration: mean lat.: 15.063ms, rate sampling interval: 41ms
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    50.51ms   66.48ms 222.72ms   78.43%
    Req/Sec    21.34     76.54   675.00     91.06%
  Latency Distribution (HdrHistogram - Recorded Latency)
 50.000%   14.42ms
 75.000%   20.30ms
 90.000%  172.93ms
 99.000%  217.60ms
 99.900%  222.85ms
 99.990%  222.85ms
 99.999%  222.85ms
100.000%  222.85ms

  Detailed Percentile spectrum:
       Value   Percentile   TotalCount 1/(1-Percentile)

       8.031     0.000000            1         1.00
      11.455     0.100000           21         1.11
      12.911     0.200000           41         1.25
      13.615     0.300000           62         1.43
      13.911     0.400000           82         1.67
      14.423     0.500000          102         2.00
      15.119     0.550000          113         2.22
      15.855     0.600000          123         2.50
      16.447     0.650000          133         2.86
      17.103     0.700000          143         3.33
      20.303     0.750000          153         4.00
     113.855     0.775000          159         4.44
     123.647     0.800000          164         5.00
     138.239     0.825000          169         5.71
     147.839     0.850000          174         6.67
     162.559     0.875000          180         8.00
     167.679     0.887500          182         8.89
     172.927     0.900000          184        10.00
     182.911     0.912500          188        11.43
     188.031     0.925000          190        13.33
     192.383     0.937500          192        16.00
     197.503     0.943750          193        17.78
     197.887     0.950000          194        20.00
     202.751     0.956250          196        22.86
     207.615     0.962500          198        26.67
     207.615     0.968750          198        32.00
     212.479     0.971875          200        35.56
     212.479     0.975000          200        40.00
     212.479     0.978125          200        45.71
     217.599     0.981250          202        53.33
     217.599     0.984375          202        64.00
     217.599     0.985938          202        71.11
     217.599     0.987500          202        80.00
     217.599     0.989062          202        91.43
     222.591     0.990625          203       106.67
     222.591     0.992188          203       128.00
     222.591     0.992969          203       142.22
     222.591     0.993750          203       160.00
     222.591     0.994531          203       182.86
     222.847     0.995313          204       213.33
     222.847     1.000000          204          inf
#[Mean    =       50.509, StdDeviation   =       66.485]
#[Max     =      222.720, Total count    =          204]
#[Buckets =           27, SubBuckets     =         2048]
----------------------------------------------------------
  752 requests in 15.01s, 420.06KB read
Requests/sec:     50.09
Transfer/sec:     27.98KB

JSON Output

{
	"requests": 752,
	"duration_in_microseconds": 15014309.00,
	"bytes": 430144,
	"requests_per_sec": 50.09,
	"bytes_transfer_per_sec": 28648.94,
	"latency_distribution": [
		{
			"percentile": 50,
			"latency_in_microseconds": 14423
		},
		{
			"percentile": 75,
			"latency_in_microseconds": 20303
		},
		{
			"percentile": 90,
			"latency_in_microseconds": 172927
		},
		{
			"percentile": 99,
			"latency_in_microseconds": 217599
		},
		{
			"percentile": 99.9,
			"latency_in_microseconds": 222847
		},
		{
			"percentile": 99.99,
			"latency_in_microseconds": 222847
		},
		{
			"percentile": 99.999,
			"latency_in_microseconds": 222847
		},
		{
			"percentile": 100,
			"latency_in_microseconds": 222847
		}
	]
}

```
I have a similar PR against `wrk` as well.  I created this new PR since output of `wrk2` has more percentiles than `wrk`. 