### PR TITLE
Fix script_copy_value for LUA_TTABLE

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -497,8 +497,8 @@ void script_copy_value(lua_State *src, lua_State *dst, int index) {
             lua_newtable(dst);
             lua_pushnil(src);
             while (lua_next(src, index - 1)) {
-                script_copy_value(src, dst, -1);
                 script_copy_value(src, dst, -2);
+                script_copy_value(src, dst, -1);
                 lua_settable(dst, -3);
                 lua_pop(src, 1);
             }


### PR DESCRIPTION
Hi,

Current implementation of `script_copy_value` is incorrect for `LUA_TTABLE` and is 'reversing' the table:

```
local threads = {}

function setup(thread)
   table.insert(threads, thread)
end

function init(args)
   statuses = {}
end

function response(status, headers, body)
   if statuses[status] then
      statuses[status] = statuses[status] + 1
   else
      statuses[status] = 1
   end
end

function done(summary, latency, requests)
   local results = {}
   for index, thread in ipairs(threads) do
      local statuses = thread:get("statuses")
      for key, value in pairs(statuses) do
         local msg = "%d - %d" 
         print(msg:format(key, value))
      end
   end
end
```

Prints smth like:
```
8 - 200
12 - 500
```

Instead of correct
```
200 - 8
500 - 12
```

This patch fixes it.