### PR TITLE
gettimeofday require "sys/time.h" include on macOS

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -6,6 +6,7 @@
 #include "http_parser.h"
 #include "stats.h"
 #include "zmalloc.h"
+#include "sys/time.h"
 
 typedef struct {
     char *name;


### PR DESCRIPTION
On Linux sys/time.h exists and contains gettimeofday, so no need to put an ifdef guard around the include.