### PR TITLE
Fixed compilation error on MacOS BigSur:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ $(ODIR)/$(OPENSSL): deps/$(OPENSSL).tar.gz | $(ODIR)
 $(ODIR)/lib/libluajit-5.1.a: $(ODIR)/$(LUAJIT)
 	@echo Building LuaJIT...
 	@$(MAKE) -C $< PREFIX=$(abspath $(ODIR)) BUILDMODE=static install
-	@cd $(ODIR)/bin && ln -s luajit-2.1.0-beta3 luajit
+	@cd $(ODIR)/bin && ln -sf luajit-2.1.0-beta3 luajit
 
 $(ODIR)/lib/libssl.a: $(ODIR)/$(OPENSSL)
 	@echo Building OpenSSL...

--- a/src/script.c
+++ b/src/script.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 #include "script.h"
 #include "http_parser.h"
 #include "stats.h"


### PR DESCRIPTION
Fixes for jr/wrk-update branch (with updates from wrk 4.1.0):
- added `#include <sys/time.h>` to src/script.c
- added `-f` option to `ln -s luajit-2.1.0-beta3 luajit` in Makefile, because without it `make` failed on repeated build without clean