### PR TITLE
Fix #112

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -497,8 +497,8 @@ void script_copy_value(lua_State *src, lua_State *dst, int index) {
             lua_newtable(dst);
             lua_pushnil(src);
             while (lua_next(src, index - 1)) {
-                script_copy_value(src, dst, -1);
                 script_copy_value(src, dst, -2);
+                script_copy_value(src, dst, -1);
                 lua_settable(dst, -3);
                 lua_pop(src, 1);
             }


### PR DESCRIPTION
The change is tiny. It seems the `script_copy_value` is relevant exactly to this problem, and the order of the operations in `wrk` 4.1.0 is like in this request: https://github.com/wg/wrk/blob/9d71b2f/src/script.c#L495-L496.

Manually checked the order of keys and values in `for k, v in pairs(threads.get(...))` is correct now.