### PR TITLE
Add ability to specify CPU affinity for wrk threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ else ifeq ($(TARGET), darwin)
 	LIBS += -L/usr/local/opt/openssl/lib
 	CFLAGS += -I/usr/local/include -I/usr/local/opt/openssl/include
 else ifeq ($(TARGET), linux)
-        CFLAGS  += -D_POSIX_C_SOURCE=200809L -D_BSD_SOURCE
+        CFLAGS  += -D_GNU_SOURCE
 	LIBS    += -ldl
 	LDFLAGS += -Wl,-E
 else ifeq ($(TARGET), freebsd)

--- a/src/units.h
+++ b/src/units.h
@@ -1,6 +1,9 @@
 #ifndef UNITS_H
 #define UNITS_H
 
+#include <sys/queue.h>
+#include <sched.h>
+
 char *format_binary(long double);
 char *format_metric(long double);
 char *format_time_us(long double);
@@ -8,5 +11,14 @@ char *format_time_s(long double);
 
 int scan_metric(char *, uint64_t *);
 int scan_time(char *, uint64_t *);
+
+struct aff_set {
+    cpu_set_t set;
+    STAILQ_ENTRY(aff_set) items;
+};
+
+STAILQ_HEAD(aff_set_head, aff_set);
+
+int scan_affinity(char *, struct aff_set_head **);
 
 #endif /* UNITS_H */

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -30,6 +30,7 @@ typedef struct {
     aeEventLoop *loop;
     struct addrinfo *addr;
     uint64_t connections;
+    cpu_set_t *cpu_set;
     int interval;
     uint64_t stop_at;
     uint64_t complete;


### PR DESCRIPTION
In some cases, it is necessary that the wrk2 threads run on a specific CPU.
Example of usage with affinity: "wrk -t 3 -a 0,1,2 -c 100 -d 5 -R 500000 <url>".

If the affinity parameter is not specified, then the threads will be run as
before (without any affinitization).